### PR TITLE
Fix single selection mode

### DIFF
--- a/fancytree/widgets.py
+++ b/fancytree/widgets.py
@@ -51,7 +51,7 @@ class FancyTreeWidget(Widget):
         self.choices = list(choices)
 
     def value_from_datadict(self, data, files, name):
-        if isinstance(data, (MultiValueDict, MergeDict)):
+        if isinstance(data, (MultiValueDict, MergeDict)) and self.select_mode != 1:
             return data.getlist(name)
         return data.get(name, None)
 


### PR DESCRIPTION
Right now we return a list when select_mode is set to 1 (single selection). This will result in "Select a valid choice" errors. To fix this we should return a single item if select_mode is 1.